### PR TITLE
Makes the skeleton whitelist only HOTFIX

### DIFF
--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -34,7 +34,7 @@ var/list/whitelist = list()
 /proc/is_alien_whitelisted(mob/M, var/species)
 	if(!config.usealienwhitelist)
 		return 1
-	if(species != "vox" && species != "Vox" && species != "diona" && species != "Diona")
+	if(species != "vox" && species != "Vox" && species != "diona" && species != "Diona" && species != "skeleton" && species != "Skeleton")
 		return 1
 	if(check_rights(R_ADMIN, 0))
 		return 1


### PR DESCRIPTION
Hotfix: makes skeletons whitelist only.